### PR TITLE
More compatibility with standard XmlDocument.

### DIFF
--- a/src/AngleSharp.Xml.Tests/Parser/XmlParsing.cs
+++ b/src/AngleSharp.Xml.Tests/Parser/XmlParsing.cs
@@ -71,5 +71,14 @@ namespace AngleSharp.Xml.Tests.Parser
             var document = parser.ParseDocument(source);
             Assert.AreEqual("&nbsp;", document.DocumentElement.TextContent);
         }
+
+        [Test]
+        public void ParseValidXmlPrefixShouldBeEmpty()
+        {
+            var source = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" />";
+            var parser = new XmlParser();
+            var document = parser.ParseDocument(source);
+            Assert.AreEqual("", document.DocumentElement.Prefix);
+        }
     }
 }

--- a/src/AngleSharp.Xml/Dom/Internal/XmlElement.cs
+++ b/src/AngleSharp.Xml/Dom/Internal/XmlElement.cs
@@ -9,11 +9,11 @@ namespace AngleSharp.Xml.Dom
     /// The object representation of an XMLElement.
     /// </summary>
     sealed class XmlElement : Element
-    {        
+    {
         #region ctor
 
-        public XmlElement(Document owner, String name, String prefix = null, String namespaceUri = null, NodeFlags flags = NodeFlags.None)
-            : base(owner, name, prefix, namespaceUri, flags)
+        public XmlElement(Document owner, String name, String prefix = "", String namespaceUri = null, NodeFlags flags = NodeFlags.None)
+            : base(owner, string.IsNullOrEmpty(prefix) ? name : prefix + ":" + name, name, prefix ?? "", namespaceUri, flags)
         {
         }
 


### PR DESCRIPTION
# Types of Changes
Use XmlElement.Prefix empty string instead null.

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

I'm trying to solve AngleSharp/AngleSharp.XPath/issues/18 issue. I found that AngleSharp.Xml uses null prefix for XmlElement, but standard XmlDocument uses empty string. I consider we need more compatibility with standard XmlDocument.

Below the same test for XmlDocument

```csharp
[Test]
public void ParseValidXmlPrefixShouldBeEmpty()
{
    var source = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" />";
    var document = new XmlDocument();
    document.LoadXml(source);
    Assert.AreEqual("", document.DocumentElement.Prefix);
}
```