### PR TITLE
Auto-identify the XML namespace Issue 20

### DIFF
--- a/src/AngleSharp.Xml.Tests/Parser/XmlParsing.cs
+++ b/src/AngleSharp.Xml.Tests/Parser/XmlParsing.cs
@@ -146,5 +146,13 @@ namespace AngleSharp.Xml.Tests.Parser
                 parser.ParseDocument(source);
             });
         }
+
+        [Test]
+        public async Task XmlPrefixedAttributesShouldLocateXmlNamespaceWithoutDeclaration()
+        {
+            var document = @"<xml xml:lang=""en""></xml>".ToXmlDocument();
+            var root = document.DocumentElement;
+            Assert.AreEqual(NamespaceNames.XmlUri, root.Attributes.Single().NamespaceUri);
+        }
     }
 }

--- a/src/AngleSharp.Xml/Parser/XmlDomBuilder.cs
+++ b/src/AngleSharp.Xml/Parser/XmlDomBuilder.cs
@@ -431,7 +431,11 @@ namespace AngleSharp.Xml.Parser
                 var prefix = name.Substring(0, colon);
                 var ns = NamespaceNames.XmlNsUri;
 
-                if (!prefix.Is(NamespaceNames.XmlNsPrefix))
+                if (prefix.Is(NamespaceNames.XmlPrefix))
+                {
+                    ns = NamespaceNames.XmlUri;
+                }
+                else if (!prefix.Is(NamespaceNames.XmlNsPrefix))
                 {
                     ns = CurrentNode.LookupNamespaceUri(prefix);
                 }


### PR DESCRIPTION
While the XML namespace may be declared it does not have to be in order to use xml namespaced attributes. This code will automatically recognize xml namespaced attributes, even if the namespace is not explicitly declared.

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [/] I have read the **CONTRIBUTING** document
- [/] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [/] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [/] I have added tests to cover my changes
- [/] All new and existing tests passed

## Description

This code change automatically associates any xml prefixed attribute with the xml namespace, without checking to see if is has been explicitly declared.
