### PR TITLE
Namespace declaration processed first. Issue 22

### DIFF
--- a/src/AngleSharp.Xml.Tests/Parser/XmlParsing.cs
+++ b/src/AngleSharp.Xml.Tests/Parser/XmlParsing.cs
@@ -1,3 +1,7 @@
+using System.Linq;
+using System.Threading.Tasks;
+using AngleSharp.Dom;
+
 namespace AngleSharp.Xml.Tests.Parser
 {
     using AngleSharp.Xml.Parser;
@@ -146,5 +150,15 @@ namespace AngleSharp.Xml.Tests.Parser
                 parser.ParseDocument(source);
             });
         }
+        }
+
+        [Test]
+        public async Task NamespaceDeclarationsInAttributesShouldNotCareAboutOrdering()
+        {
+            var document = @"<xml p6:type=""noteref"" xmlns:p6=""http://www.idpf.org/2007/ops"" >1</xml>"
+                .ToXmlDocument();
+            var root = document.DocumentElement;
+            Assert.AreEqual("http://www.idpf.org/2007/ops",
+                root.Attributes.First(att => att.LocalName == "type").NamespaceUri);
     }
 }

--- a/src/AngleSharp.Xml/Parser/XmlDomBuilder.cs
+++ b/src/AngleSharp.Xml/Parser/XmlDomBuilder.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace AngleSharp.Xml.Parser
 {
     using AngleSharp.Dom;
@@ -274,9 +276,23 @@ namespace AngleSharp.Xml.Parser
                     var element = CreateElement(tagToken.Name, tagToken.IsSelfClosing);
                     CurrentNode.AppendChild(element);
 
-                    for (var i = 0; i < tagToken.Attributes.Count; i++)
+                    var namespaceDeclarations = tagToken.Attributes
+                        .Where(attr => attr.Key.StartsWith("xmlns"))
+                        .ToList();
+                    var otherAttributes = tagToken.Attributes
+                        .Where(attr => !attr.Key.StartsWith("xmlns"))
+                        .ToList();
+
+                    for (var i = 0; i < namespaceDeclarations.Count; i++)
                     {
-                        var attr = tagToken.Attributes[i];
+                        var attr = namespaceDeclarations[i];
+                        var item = CreateAttribute(attr.Key, attr.Value.Trim());
+                        element.AddAttribute(item);
+                    }
+
+                    for (var i = 0; i < otherAttributes.Count; i++)
+                    {
+                        var attr = otherAttributes[i];
                         var item = CreateAttribute(attr.Key, attr.Value.Trim());
                         element.AddAttribute(item);
                     }


### PR DESCRIPTION
If a namespace is declared after an attribute that uses that namespace, the namespace should still be correctly identified. This code change causes any namespace declarations to be processed before other attributes.

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [/] I have read the **CONTRIBUTING** document
- [/] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [/] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [/] I have added tests to cover my changes
- [/] All new and existing tests passed

## Description

This code change causes any namespace declaration attributes to be processed before the other attributes, so if they make use of said namespaces, the namespace will have been registered and will be properly identified.
